### PR TITLE
fix(auth): enable email endpoints for authenticated users

### DIFF
--- a/src/main/java/com/talentprobe/assessment/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/talentprobe/assessment/config/JwtAuthenticationFilter.java
@@ -35,20 +35,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        final String jwt = authHeader.substring(7);
-        final String userEmail = jwtUtil.extractEmail(jwt);
+        try {
+            final String jwt = authHeader.substring(7);
+            final String userEmail = jwtUtil.extractEmail(jwt);
 
-        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
+            if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
 
-            if (jwtUtil.isTokenValid(jwt)) {
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities()
-                );
-                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authToken);
+                if (jwtUtil.isTokenValid(jwt)) {
+                    UsernamePasswordAuthenticationToken authToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails,
+                                    null,
+                                    userDetails.getAuthorities()
+                            );
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
             }
+        } catch (Exception e) {
+
         }
+
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/auth/")
+                || path.startsWith("/swagger-ui/")
+                || path.startsWith("/v3/api-docs/")
+                || (path.equals("/users") && request.getMethod().equals("POST"));
     }
 }

--- a/src/main/java/com/talentprobe/assessment/config/OpenApiConfig.java
+++ b/src/main/java/com/talentprobe/assessment/config/OpenApiConfig.java
@@ -9,7 +9,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @OpenAPIDefinition(
-        info = @Info(title = "Assessment Platform API", version = "v1")
+        info = @Info(title = "Assessment Platform API", version = "v1"),
+        security = @SecurityRequirement(name = "bearerAuth")
 )
 @SecurityScheme(
         name = "bearerAuth",

--- a/src/main/java/com/talentprobe/assessment/config/SecurityConfig.java
+++ b/src/main/java/com/talentprobe/assessment/config/SecurityConfig.java
@@ -1,58 +1,66 @@
 package com.talentprobe.assessment.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.talentprobe.assessment.exception.GlobalExceptionHandler.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.time.LocalDateTime;
 
 @Configuration
-@EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
-    private final AuthenticationProvider authenticationProvider;
-    private final CorsConfigurationSource corsConfigurationSource;
+    private final ObjectMapper objectMapper;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> {
+                            ApiResponse body = new ApiResponse(
+                                    false,
+                                    HttpStatus.UNAUTHORIZED.value(),
+                                    "Unauthorized",
+                                    "Unauthorized: Invalid or missing token",
+                                    LocalDateTime.now()
+                            );
+                            res.setStatus(HttpStatus.UNAUTHORIZED.value());
+                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            res.getWriter().write(objectMapper.writeValueAsString(body));
+                        })
+                        .accessDeniedHandler((req, res, e) -> {
+                            ApiResponse body = new ApiResponse(
+                                    false,
+                                    HttpStatus.FORBIDDEN.value(),
+                                    "Forbidden",
+                                    "Access denied. Admin role required",
+                                    LocalDateTime.now()
+                            );
+                            res.setStatus(HttpStatus.FORBIDDEN.value());
+                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            res.getWriter().write(objectMapper.writeValueAsString(body));
+                        })
+                )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("POST", "/users").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
-                                        // Swagger
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                                        // Auth
-                        .requestMatchers("/auth/login").permitAll()
-                                        // Candidate registration
-                        .requestMatchers(HttpMethod.POST, "/users").permitAll()
-                                        // Candidate assessment flow (no token needed)
-                        .requestMatchers(HttpMethod.GET, "/api/assignments/validate").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/attempt/start").permitAll()
-                        .requestMatchers(HttpMethod.PUT, "/api/attempt/*/submit").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/attempt/*").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/attempt/candidate/*").permitAll()
-                                        // Candidate submissions (no token needed)
-                        .requestMatchers(HttpMethod.POST, "/submissions").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/submissions/*").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/submissions/attempt/*").permitAll()
-                                        // Everything else requires authentication
-                        .anyRequest().hasRole("ADMIN")
-
-                );
         return http.build();
     }
 }

--- a/src/main/java/com/talentprobe/assessment/controller/AuthController.java
+++ b/src/main/java/com/talentprobe/assessment/controller/AuthController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-@Tag(name = "Authentication", description = "Authentication endpoints")
+@Tag(name = "1. Authentication", description = "Authentication endpoints")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/talentprobe/assessment/controller/UserController.java
+++ b/src/main/java/com/talentprobe/assessment/controller/UserController.java
@@ -8,7 +8,6 @@ import com.talentprobe.assessment.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -34,27 +33,19 @@ import java.util.UUID;
 @RequestMapping("/users")
 @RequiredArgsConstructor
 @Validated
+@Tag(name = "2. User Management", description = "Candidate registration and admin user management")
 public class UserController {
+
     private final UserService userService;
 
-    @Tag(name = "Public - Candidate Registration")
-    @Operation(summary = "Register candidate", description = "All fields required.")
+    @Operation(summary = "Register candidate", description = "Public endpoint. All fields required.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserResponseDto>> createCandidate(
-            @RequestParam("name") @NotBlank(message = "Name is required")
-            @Parameter(description = "Full name", required = true) String name,
-
-            @RequestParam("email") @Email(message = "Email must be valid") @NotBlank(message = "Email is required")
-            @Parameter(description = "Email address", required = true) String email,
-
-            @RequestParam("phoneNumber") @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Phone number must be 10-15 digits") @NotBlank(message = "Phone number is required")
-            @Parameter(description = "Phone with country code", required = true) String phoneNumber,
-
-            @RequestParam("language") @NotNull(message = "Programming language is required")
-            @Parameter(description = "Choose programming language", required = true, schema = @Schema(implementation = Language.class)) Language language,
-
-            @RequestPart(value = "idDocument", required = false)
-            @Parameter(description = "Upload ID: PDF, JPG, PNG, max 10MB", required = false) MultipartFile idDocument
+            @RequestParam("name") @NotBlank String name,
+            @RequestParam("email") @Email @NotBlank String email,
+            @RequestParam("phoneNumber") @Pattern(regexp = "^\\+?[0-9]{10,15}$") @NotBlank String phoneNumber,
+            @RequestParam("language") @NotNull Language language,
+            @RequestPart(value = "idDocument", required = false) MultipartFile idDocument
     ) throws IOException {
 
         UserDto dto = new UserDto();
@@ -69,18 +60,14 @@ public class UserController {
                 .body(ApiResponse.success("Candidate registered successfully", created));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "Get all candidates", description = "ADMIN only. Returns CANDIDATE.")
+    @Operation(summary = "Get all candidates")
     @GetMapping
     public ResponseEntity<ApiResponse<List<UserResponseDto>>> getAllCandidates() {
         List<UserResponseDto> users = userService.getAllCandidates();
         return ResponseEntity.ok(ApiResponse.success("Successfully Retrieved", users));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto>> getUserById(@PathVariable UUID id) {
@@ -88,25 +75,15 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("Successfully Retrieved", user));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "Full update candidate", description = "ADMIN only. All fields required.")
+    @Operation(summary = "Full update candidate")
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto>> updateUser(
             @PathVariable UUID id,
-
-            @RequestParam("name") @NotBlank(message = "Name is required")
-            @Parameter(description = "Full name", required = true) String name,
-
-            @RequestParam("email") @Email(message = "Email must be valid") @NotBlank(message = "Email is required")
-            @Parameter(description = "Email address", required = true) String email,
-
-            @RequestParam("phoneNumber") @Pattern(regexp = "^\\+?[0-9]{10,15}$", message = "Phone number must be 10-15 digits") @NotBlank(message = "Phone number is required")
-            @Parameter(description = "Phone with country code", required = true) String phoneNumber,
-
-            @RequestParam("language") @NotNull(message = "Programming language is required")
-            @Parameter(description = "Choose programming language", required = true, schema = @Schema(implementation = Language.class)) Language language
+            @RequestParam("name") @NotBlank String name,
+            @RequestParam("email") @Email @NotBlank String email,
+            @RequestParam("phoneNumber") @Pattern(regexp = "^\\+?[0-9]{10,15}$") @NotBlank String phoneNumber,
+            @RequestParam("language") @NotNull Language language
     ) {
         UserDto dto = new UserDto();
         dto.setName(name);
@@ -119,25 +96,15 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("Successfully Updated", updated));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Partial update candidate")
     @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserResponseDto>> patchUser(
             @PathVariable UUID id,
-
-            @RequestParam(value = "name", required = false)
-            @Parameter(description = "New full name", required = false) String name,
-
-            @RequestParam(value = "phoneNumber", required = false)
-            @Parameter(description = "New phone with country code", required = false) String phoneNumber,
-
-            @RequestParam(value = "language", required = false)
-            @Parameter(description = "Choose programming language", required = false, schema = @Schema(implementation = Language.class)) Language language,
-
-            @RequestPart(value = "idDocument", required = false)
-            @Parameter(description = "Upload new ID: PDF, JPG, PNG, max 10MB", required = false) MultipartFile idDocument
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "phoneNumber", required = false) String phoneNumber,
+            @RequestParam(value = "language", required = false) Language language,
+            @RequestPart(value = "idDocument", required = false) MultipartFile idDocument
     ) throws IOException {
         UserPatchRequest dto = new UserPatchRequest();
         dto.setName(name);
@@ -149,8 +116,6 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("Successfully Updated", updated));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable UUID id) {
@@ -158,8 +123,6 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("User deleted successfully", null));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{id}/activate")
     public ResponseEntity<ApiResponse<UserResponseDto>> activateUser(@PathVariable UUID id) {
@@ -167,8 +130,6 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("User activated successfully", updated));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{id}/deactivate")
     public ResponseEntity<ApiResponse<UserResponseDto>> deactivateUser(@PathVariable UUID id) {
@@ -176,10 +137,8 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("User deactivated successfully", updated));
     }
 
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "Download candidate ID document", description = "ADMIN only. Returns file with original name and type.")
+    @Operation(summary = "Download candidate ID document")
     @GetMapping("/{id}/id-document")
     public ResponseEntity<Resource> downloadIdDocument(@PathVariable UUID id) {
         User user = userService.getUserEntity(id);
@@ -194,11 +153,10 @@ public class UserController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
                 .body(resource);
     }
-    @Tag(name = "Admin - Management")
-    @SecurityRequirement(name = "bearerAuth")
+
     @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/admin/replace")
-    @Operation(summary = "Replace admin credentials", description = "Use when admin is fired. Updates current admin's name/email/password.")
+    @Operation(summary = "Replace admin credentials")
     public ResponseEntity<ApiResponse<UserResponseDto>> replaceAdmin(
             @RequestParam @NotBlank String name,
             @RequestParam @Email @NotBlank String email,
@@ -207,8 +165,7 @@ public class UserController {
         UserResponseDto updated = userService.replaceAdmin(name, email, newPassword);
         return ResponseEntity.ok(ApiResponse.success("Admin credentials replaced successfully", updated));
     }
-    @Tag(name = "Admin - User Management")
-    @SecurityRequirement(name = "bearerAuth")
+
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Bulk upload candidates from Excel")
     @PostMapping(value = "/bulk-upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/talentprobe/assessment/exception/ForbiddenException.java
+++ b/src/main/java/com/talentprobe/assessment/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.talentprobe.assessment.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/talentprobe/assessment/exception/UnauthorizedException.java
+++ b/src/main/java/com/talentprobe/assessment/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.talentprobe.assessment.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/talentprobe/assessment/util/JwtUtil.java
+++ b/src/main/java/com/talentprobe/assessment/util/JwtUtil.java
@@ -5,10 +5,14 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class JwtUtil {
@@ -23,10 +27,24 @@ public class JwtUtil {
     }
 
     public String generateToken(String email, String userId, String role) {
+        return generateToken(email, userId, role, List.of());
+    }
+
+    public String generateToken(String email, String userId, String role, Collection<? extends GrantedAuthority> authorities) {
+        List<String> authList = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .map(auth -> auth.startsWith("ROLE_") ? auth : "ROLE_" + auth)
+                .collect(Collectors.toList());
+
+        if (authList.isEmpty() && role != null) {
+            authList = List.of(role.startsWith("ROLE_") ? role : "ROLE_" + role);
+        }
+
         return Jwts.builder()
                 .setSubject(email)
                 .claim("userId", userId)
                 .claim("role", role)
+                .claim("authorities", authList)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,6 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -30,3 +29,7 @@ brevo:
   sender:
     email: ${BREVO_SENDER_EMAIL}
     name: ${BREVO_SENDER_NAME}
+
+logging:
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
Add ForbiddenException and UnauthorizedException for auth error handling. Update SecurityConfig and JwtAuthenticationFilter to return 401/403 JSON responses and allow valid JWT users to access /api/email/result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication and authorization failures now return structured JSON error responses.
  * Public endpoints are now clearly defined, including authentication routes, user registration, and API documentation.

* **Bug Fixes**
  * JWT filter now gracefully handles token validation errors without breaking the request pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SheCanCODE-Capstone-Projects/Assessment_Platfrom_be/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->